### PR TITLE
Do apply -f rather than create -f on the service-monitor template

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ $ oc process -f fuse-prometheus-operator.yml  -p NAMESPACE=<YOUR NAMESPACE> | oc
 Finally, tell it to monitor your fuse application:
 
 ```
-$ oc process -f fuse-servicemonitor.yml -p NAMESPACE=<YOUR NAMESPACE> FUSE_SERVICE_NAME=<YOUR FUSE SERVICE> | oc create -f -
+$ oc process -f fuse-servicemonitor.yml -p NAMESPACE=<YOUR NAMESPACE> FUSE_SERVICE_NAME=<YOUR FUSE SERVICE> | oc apply -f -
 ```
 
 Note that the `NAMESPACE` and `FUSE_SERVICE_NAME` parameters must be specified.


### PR DESCRIPTION
Do apply -f rather than create -f on the service-monitor template.