### PR TITLE
ENTESB-10808: OCP 4.1 - prometheus-operator: Deployment in version v1…

### DIFF
--- a/fuse-prometheus-operator.yml
+++ b/fuse-prometheus-operator.yml
@@ -173,7 +173,7 @@ objects:
           image: quay.io/coreos/prometheus-operator:v0.24.0
           name: prometheus-operator
           ports:
-          - containerPort: ${CONTAINER_PORT}
+          - containerPort: ${{CONTAINER_PORT}}
             name: http
           resources:
             limits:
@@ -214,7 +214,7 @@ objects:
     type: NodePort
     ports:
     - name: ${PORT_NAME} 
-      port: ${PROMETHEUS_SERVICE_PORT}
+      port: ${{PROMETHEUS_SERVICE_PORT}}
       protocol: TCP 
       targetPort: ${PORT_NAME}
     selector:


### PR DESCRIPTION
…beta2 cannot be handled as a Deployment