### PR TITLE
Add back 7.4 image streams

### DIFF
--- a/fis-image-streams.json
+++ b/fis-image-streams.json
@@ -777,6 +777,21 @@
                         }
                     },
                     {
+                        "name": "1.4",
+                        "annotations": {
+                            "description": "Red Hat Apicurito UI image.",
+                            "openshift.io/display-name": "Red Hat Apicurito UI",
+                            "tags": "apicurio,hidden"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/fuse7/fuse-apicurito:1.4"
+                        }
+                    },
+                    {
                         "name": "1.5",
                         "annotations": {
                             "description": "Red Hat Apicurito UI image.",

--- a/fis-image-streams.json
+++ b/fis-image-streams.json
@@ -852,6 +852,21 @@
                         }
                     },
                     {
+                        "name": "1.4",
+                        "annotations": {
+                            "description": "Red Hat Apicurito Generator image.",
+                            "openshift.io/display-name": "Red Hat Apicurito Generator",
+                            "tags": "apicurio,fuse,hidden"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/fuse7/fuse-apicurito-generator:1.4"
+                        }
+                    },
+                    {
                         "name": "1.5",
                         "annotations": {
                             "description": "Red Hat Apicurito Generator image.",

--- a/fis-image-streams.json
+++ b/fis-image-streams.json
@@ -327,6 +327,24 @@
                         }
                     },
                     {
+                        "name": "1.4",
+                        "annotations": {
+                            "description": "Red Hat Fuse 7.4 Java S2I images.",
+                            "openshift.io/display-name": "Red Hat Fuse 7.4 Java",
+                            "iconClass": "icon-rh-integration",
+                            "tags": "builder,jboss-fuse,java,xpaas,hidden",
+                            "supports":"jboss-fuse:7.4.0,java:8,xpaas:1.2",
+                            "version": "1.4"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/fuse7/fuse-java-openshift:1.4"
+                        }
+                    },
+                    {
                         "name": "1.5",
                         "annotations": {
                             "description": "Red Hat Fuse 7.5 Java S2I images.",
@@ -430,6 +448,24 @@
                             "kind": "DockerImage",
                             "name": "registry.redhat.io/fuse7/fuse-karaf-openshift:1.3"
                         }                    
+                    },
+                    {
+                        "name": "1.4",
+                        "annotations": {
+                            "description": "Red Hat Fuse 7.4 Karaf S2I images.",
+                            "openshift.io/display-name": "Red Hat Fuse 7.4 Karaf",
+                            "iconClass": "icon-rh-integration",
+                            "tags": "builder,jboss-fuse,java,karaf,xpaas,hidden",
+                            "supports":"jboss-fuse:7.4.0,java:8,xpaas:1.2",
+                            "version": "1.4"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/fuse7/fuse-karaf-openshift:1.4"
+                        }
                     },
                     {
                         "name": "1.5",
@@ -537,6 +573,24 @@
                         }
                     },
                     {
+                        "name": "1.4",
+                        "annotations": {
+                            "description": "Red Hat Fuse 7.4 EAP S2I images.",
+                            "openshift.io/display-name": "Red Hat Fuse 7.4 EAP",
+                            "iconClass": "icon-rh-integration",
+                            "tags": "builder,jboss-fuse,java,eap,xpaas,hidden",
+                            "supports":"jboss-fuse:7.4.0,java:8,xpaas:1.2",
+                            "version": "1.4"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/fuse7/fuse-eap-openshift:1.4"
+                        }
+                    },
+                    {
                         "name": "1.5",
                         "annotations": {
                             "description": "Red Hat Fuse 7.5 EAP S2I images.",
@@ -639,6 +693,24 @@
                         "from": {
                             "kind": "DockerImage",
                             "name": "registry.redhat.io/fuse7/fuse-console:1.3"
+                        }
+                    },
+                    {
+                        "name": "1.4",
+                        "annotations": {
+                            "description": "Red Hat Fuse 7.4 Console image.",
+                            "openshift.io/display-name": "Red Hat Fuse 7.4 Console",
+                            "iconClass": "icon-rh-integration",
+                            "tags": "jboss-fuse,hawtio,java,xpaas,hidden",
+                            "supports":"jboss-fuse:7.4.0,java:8,xpaas:1.2",
+                            "version": "1.4"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/fuse7/fuse-console:1.4"
                         }
                     },
                     {


### PR DESCRIPTION
In https://github.com/jboss-fuse/application-templates/pull/79 I mistakenly substituted 7.5 into the 7.4 image streams rather than adding the 7.5 streams.     This commit adds the missing 7.4 streams back - my apologies!