### PR TITLE
[2.1.x.redhat-7-x] ENTESB-12941 prometheus doesn't work with OCP 4.4

### DIFF
--- a/fuse-prometheus-operator.yml
+++ b/fuse-prometheus-operator.yml
@@ -146,7 +146,7 @@ objects:
     - list
     - watch
 
-- apiVersion: apps/v1beta2
+- apiVersion: apps/v1
   kind: Deployment
   metadata:
     labels:
@@ -169,8 +169,8 @@ objects:
           - --namespaces=${NAMESPACE}
           - --logtostderr=true
           - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
-          - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.29.0
-          image: quay.io/coreos/prometheus-operator:v0.29.0
+          - --prometheus-config-reloader=quay.io/coreos/prometheus-config-reloader:v0.30.1
+          image: quay.io/coreos/prometheus-operator:v0.30.1
           name: prometheus-operator
           ports:
           - containerPort: ${{CONTAINER_PORT}}

--- a/quickstarts/spring-boot-camel-xa-template.json
+++ b/quickstarts/spring-boot-camel-xa-template.json
@@ -294,7 +294,7 @@
     },
     {
       "kind": "StatefulSet",
-      "apiVersion": "apps/v1beta1",
+      "apiVersion": "apps/v1",
       "metadata": {
         "name": "${APP_NAME}",
         "labels": {


### PR DESCRIPTION
Changes based on https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/