### PR TITLE
ENTESB-13089: S2I build for EAP CXF JAXRS quickstart on OCP 4.2 fails with OOMKilled

### DIFF
--- a/quickstarts/eap-camel-cxf-jaxrs-template.json
+++ b/quickstarts/eap-camel-cxf-jaxrs-template.json
@@ -183,7 +183,7 @@
     {
       "name": "BUILD_MEMORY_LIMIT",
       "displayName": "Build Memory limit",
-      "value": "0.8G",
+      "value": "1G",
       "required": true,
       "description": "The amount of memory the build container is limited to use."
     }


### PR DESCRIPTION
… with OOMKilled