### PR TITLE
[ENTESB-12695] Versions in application-templates need to be parameterized

### DIFF
--- a/update-fuse-version.sh
+++ b/update-fuse-version.sh
@@ -1,0 +1,25 @@
+# Update Fuse version in application templates
+#
+# Usage: ./update-fuse-version FUSE_VERSION
+#
+# Example: 
+# > ./update-fuse-version 7.7
+#
+
+FUSE_VERSION=$1
+FUSE_NAME="fuse${FUSE_VERSION//.}"
+
+if [[ $# -eq 0 ]] ; then
+  echo Fuse version must be specified
+  exit 0
+fi
+
+for file in quickstarts/*.json *.json
+do
+  if [ "$file" = "fis-image-streams.json" ] ; then
+    # ignore fis-image-streams.json as it contains older Fuse versions
+    continue
+  fi
+  sed -i -E "s/Fuse [0-9]+\.[0-9]+\.?[0-9]*/Fuse ${FUSE_VERSION}/" $file
+  sed -i -E "s/fuse[0-9][0-9]+/${FUSE_NAME}/" $file
+done


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ENTESB-12695

A short script for updating Fuse version in all the application templates and json files (except for fis-image-stream.json which contains a lot of old Fuse versions). When updating Fuse to 7.7, just run ./update-fuse-versions.sh 7.7 and it should overwrite all "Fuse 7.6" to "Fuse 7.7" and all "fuse76" to "fuse77" and check the changes. 