### PR TITLE
[ENTESB-14400][ENTESB-14790] Provide metering labels for Fuse on Openshift resources

### DIFF
--- a/fis-console-cluster-template.json
+++ b/fis-console-cluster-template.json
@@ -195,7 +195,12 @@
               "deploymentconfig": "${APP_NAME}",
               "group": "console",
               "app": "${APP_NAME}",
-              "version": "${APP_VERSION}"
+              "version": "${APP_VERSION}",
+              "com.company": "Red_Hat",
+              "rht.prod_name": "Red_Hat_Integration",
+              "rht.prod_ver": "7.8",
+              "rht.comp": "${APP_NAME}",
+              "rht.comp_ver": "${APP_VERSION}"
             }
           },
           "spec": {

--- a/fis-console-namespace-template.json
+++ b/fis-console-namespace-template.json
@@ -201,7 +201,12 @@
               "deploymentconfig": "${APP_NAME}",
               "group": "console",
               "app": "${APP_NAME}",
-              "version": "${APP_VERSION}"
+              "version": "${APP_VERSION}",
+              "com.company": "Red_Hat",
+              "rht.prod_name": "Red_Hat_Integration",
+              "rht.prod_ver": "7.8",
+              "rht.comp": "${APP_NAME}",
+              "rht.comp_ver": "${APP_VERSION}"
             }
           },
           "spec": {

--- a/fuse-console-cluster-os4.json
+++ b/fuse-console-cluster-os4.json
@@ -195,7 +195,12 @@
               "deploymentconfig": "${APP_NAME}",
               "group": "console",
               "app": "${APP_NAME}",
-              "version": "${APP_VERSION}"
+              "version": "${APP_VERSION}",
+              "com.company": "Red_Hat",
+              "rht.prod_name": "Red_Hat_Integration",
+              "rht.prod_ver": "7.8",
+              "rht.comp": "${APP_NAME}",
+              "rht.comp_ver": "${APP_VERSION}"
             }
           },
           "spec": {

--- a/fuse-console-namespace-os4.json
+++ b/fuse-console-namespace-os4.json
@@ -201,7 +201,12 @@
               "deploymentconfig": "${APP_NAME}",
               "group": "console",
               "app": "${APP_NAME}",
-              "version": "${APP_VERSION}"
+              "version": "${APP_VERSION}",
+              "com.company": "Red_Hat",
+              "rht.prod_name": "Red_Hat_Integration",
+              "rht.prod_ver": "7.8",
+              "rht.comp": "${APP_NAME}",
+              "rht.comp_ver": "${APP_VERSION}"
             }
           },
           "spec": {


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ENTESB-14790

Some of the metering labels are missing in 2.1.x.sb2.redhat-7-8-x