### PR TITLE
[ENTESB-15984] Replace -Dfabric8 parameters with -Djkube

### DIFF
--- a/quickstarts/karaf-camel-amq-template.json
+++ b/quickstarts/karaf-camel-amq-template.json
@@ -51,7 +51,7 @@
     {
       "name": "MAVEN_ARGS",
       "displayName": "Maven Arguments",
-      "value": "install -DskipTests -Dfabric8.skip -e -B",
+      "value": "install -DskipTests -Djkube.skip -e -B",
       "description": "Arguments passed to mvn in the build."
     },
     {

--- a/quickstarts/karaf-camel-log-template.json
+++ b/quickstarts/karaf-camel-log-template.json
@@ -51,7 +51,7 @@
     {
       "name": "MAVEN_ARGS",
       "displayName": "Maven Arguments",
-      "value": "install -DskipTests -Dfabric8.skip -e -B",
+      "value": "install -DskipTests -Djkube.skip -e -B",
       "description": "Arguments passed to mvn in the build."
     },
     {

--- a/quickstarts/karaf-camel-rest-sql-template.json
+++ b/quickstarts/karaf-camel-rest-sql-template.json
@@ -81,7 +81,7 @@
     {
       "name": "MAVEN_ARGS",
       "displayName": "Maven Arguments",
-      "value": "install -DskipTests -Dfabric8.skip -e -B",
+      "value": "install -DskipTests -Djkube.skip -e -B",
       "description": "Arguments passed to mvn in the build."
     },
     {

--- a/quickstarts/karaf-cxf-rest-template.json
+++ b/quickstarts/karaf-cxf-rest-template.json
@@ -57,7 +57,7 @@
     {
       "name": "MAVEN_ARGS",
       "displayName": "Maven Arguments",
-      "value": "install -DskipTests -Dfabric8.skip -e -B",
+      "value": "install -DskipTests -Djkube.skip -e -B",
       "description": "Arguments passed to mvn in the build."
     },
     {

--- a/quickstarts/spring-boot-2-camel-amq-template.json
+++ b/quickstarts/spring-boot-2-camel-amq-template.json
@@ -100,7 +100,7 @@
     {
       "name": "MAVEN_ARGS",
       "displayName": "Maven Arguments",
-      "value": "package -DskipTests -Dfabric8.skip -e -B",
+      "value": "package -DskipTests -Djkube.skip -e -B",
       "description": "Arguments passed to mvn in the build."
     },
     {

--- a/quickstarts/spring-boot-2-camel-config-template.json
+++ b/quickstarts/spring-boot-2-camel-config-template.json
@@ -78,7 +78,7 @@
     {
       "name": "MAVEN_ARGS",
       "displayName": "Maven Arguments",
-      "value": "package -DskipTests -Dfabric8.skip -e -B",
+      "value": "package -DskipTests -Djkube.skip -e -B",
       "description": "Arguments passed to mvn in the build."
     },
     {

--- a/quickstarts/spring-boot-2-camel-drools-template.json
+++ b/quickstarts/spring-boot-2-camel-drools-template.json
@@ -77,7 +77,7 @@
     {
       "name": "MAVEN_ARGS",
       "displayName": "Maven Arguments",
-      "value": "package -DskipTests -Dfabric8.skip -e -B",
+      "value": "package -DskipTests -Djkube.skip -e -B",
       "description": "Arguments passed to mvn in the build."
     },
     {

--- a/quickstarts/spring-boot-2-camel-infinispan-template.json
+++ b/quickstarts/spring-boot-2-camel-infinispan-template.json
@@ -64,7 +64,7 @@
     {
       "name": "MAVEN_ARGS",
       "displayName": "Maven Arguments",
-      "value": "package -DskipTests -Dfabric8.skip -e -B",
+      "value": "package -DskipTests -Djkube.skip -e -B",
       "description": "Arguments passed to mvn in the build."
     },
     {

--- a/quickstarts/spring-boot-2-camel-rest-3scale-template.json
+++ b/quickstarts/spring-boot-2-camel-rest-3scale-template.json
@@ -63,7 +63,7 @@
     {
       "name": "MAVEN_ARGS",
       "displayName": "Maven Arguments",
-      "value": "package -DskipTests -Dfabric8.skip -e -B",
+      "value": "package -DskipTests -Djkube.skip -e -B",
       "description": "Arguments passed to mvn in the build."
     },
     {

--- a/quickstarts/spring-boot-2-camel-rest-sql-template.json
+++ b/quickstarts/spring-boot-2-camel-rest-sql-template.json
@@ -86,7 +86,7 @@
     {
       "name": "MAVEN_ARGS",
       "displayName": "Maven Arguments",
-      "value": "package -DskipTests -Dfabric8.skip -e -B",
+      "value": "package -DskipTests -Djkube.skip -e -B",
       "description": "Arguments passed to mvn in the build."
     },
     {

--- a/quickstarts/spring-boot-2-camel-soap-rest-bridge-template.json
+++ b/quickstarts/spring-boot-2-camel-soap-rest-bridge-template.json
@@ -57,7 +57,7 @@
     {
       "name": "MAVEN_ARGS",
       "displayName": "Maven Arguments",
-      "value": "package -DskipTests -Dfabric8.skip -e -B",
+      "value": "package -DskipTests -Djkube.skip -e -B",
       "description": "Arguments passed to mvn in the build."
     },
     {

--- a/quickstarts/spring-boot-2-camel-template.json
+++ b/quickstarts/spring-boot-2-camel-template.json
@@ -57,7 +57,7 @@
     {
       "name": "MAVEN_ARGS",
       "displayName": "Maven Arguments",
-      "value": "package -DskipTests -Dfabric8.skip -e -B",
+      "value": "package -DskipTests -Djkube.skip -e -B",
       "description": "Arguments passed to mvn in the build."
     },
     {

--- a/quickstarts/spring-boot-2-camel-xa-template.json
+++ b/quickstarts/spring-boot-2-camel-xa-template.json
@@ -102,7 +102,7 @@
     {
       "name": "MAVEN_ARGS",
       "displayName": "Maven Arguments",
-      "value": "package -DskipTests -Dfabric8.skip -e -B",
+      "value": "package -DskipTests -Djkube.skip -e -B",
       "description": "Arguments passed to mvn in the build."
     },
     {

--- a/quickstarts/spring-boot-2-camel-xml-template.json
+++ b/quickstarts/spring-boot-2-camel-xml-template.json
@@ -57,7 +57,7 @@
     {
       "name": "MAVEN_ARGS",
       "displayName": "Maven Arguments",
-      "value": "package -DskipTests -Dfabric8.skip -e -B",
+      "value": "package -DskipTests -Djkube.skip -e -B",
       "description": "Arguments passed to mvn in the build."
     },
     {

--- a/quickstarts/spring-boot-2-cxf-jaxrs-template.json
+++ b/quickstarts/spring-boot-2-cxf-jaxrs-template.json
@@ -63,7 +63,7 @@
     {
       "name": "MAVEN_ARGS",
       "displayName": "Maven Arguments",
-      "value": "package -DskipTests -Dfabric8.skip -e -B",
+      "value": "package -DskipTests -Djkube.skip -e -B",
       "description": "Arguments passed to mvn in the build."
     },
     {

--- a/quickstarts/spring-boot-2-cxf-jaxrs-xml-template.json
+++ b/quickstarts/spring-boot-2-cxf-jaxrs-xml-template.json
@@ -63,7 +63,7 @@
     {
       "name": "MAVEN_ARGS",
       "displayName": "Maven Arguments",
-      "value": "package -DskipTests -Dfabric8.skip -e -B",
+      "value": "package -DskipTests -Djkube.skip -e -B",
       "description": "Arguments passed to mvn in the build."
     },
     {

--- a/quickstarts/spring-boot-2-cxf-jaxws-template.json
+++ b/quickstarts/spring-boot-2-cxf-jaxws-template.json
@@ -63,7 +63,7 @@
     {
       "name": "MAVEN_ARGS",
       "displayName": "Maven Arguments",
-      "value": "package -DskipTests -Dfabric8.skip -e -B",
+      "value": "package -DskipTests -Djkube.skip -e -B",
       "description": "Arguments passed to mvn in the build."
     },
     {

--- a/quickstarts/spring-boot-2-cxf-jaxws-xml-template.json
+++ b/quickstarts/spring-boot-2-cxf-jaxws-xml-template.json
@@ -63,7 +63,7 @@
     {
       "name": "MAVEN_ARGS",
       "displayName": "Maven Arguments",
-      "value": "package -DskipTests -Dfabric8.skip -e -B",
+      "value": "package -DskipTests -Djkube.skip -e -B",
       "description": "Arguments passed to mvn in the build."
     },
     {


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ENTESB-15984

With migration to OMP, all parameters should start with _jkube_