### PR TITLE
[ENTESB-16283] Missing metering labels on spring-boot-camel-xa quickstart

### DIFF
--- a/quickstarts/spring-boot-2-camel-xa-template.json
+++ b/quickstarts/spring-boot-2-camel-xa-template.json
@@ -335,7 +335,12 @@
               "app": "${APP_NAME}",
               "provider": "s2i",
               "version": "${APP_VERSION}",
-              "group": "quickstarts"
+              "group": "quickstarts",
+              "com.company": "Red_Hat",
+              "rht.prod_name": "Red_Hat_Integration",
+              "rht.prod_ver": "7.9",
+              "rht.comp": "${APP_NAME}",
+              "rht.comp_ver": "${APP_VERSION}"
             }
           },
           "spec": {


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ENTESB-16283