### PR TITLE
[ENTESB-16529] S2I Quickstart Spring Boot Soap2Rest doesn't have Route definition in application template

### DIFF
--- a/quickstarts/spring-boot-2-camel-soap-rest-bridge-template.json
+++ b/quickstarts/spring-boot-2-camel-soap-rest-bridge-template.json
@@ -37,6 +37,12 @@
       "description": "Set this to a branch name, tag or other ref of your repository if you are not using the default branch."
     },
     {
+      "name": "SERVICE_NAME",
+      "displayName": "Service Name",
+      "value": "camel-soap-rest-bridge",
+      "description": "Exposed service name."
+    },
+    {
       "name": "BASE_IMAGE_NAME",
       "displayName": "Base Image Name, JDK11 or JDK8",
       "value": "fuse7-java-openshift",
@@ -134,6 +140,59 @@
     }
   ],
   "objects": [
+    {
+      "apiVersion": "v1",
+      "kind": "Route",
+      "metadata": {
+        "labels": {
+          "component": "${APP_NAME}",
+          "provider": "s2i",
+          "app": "${APP_NAME}",
+          "version": "${APP_VERSION}",
+          "group": "quickstarts"
+        },
+        "name": "${SERVICE_NAME}-route"
+      },
+      "spec": {
+        "to": {
+          "kind": "Service",
+          "name": "${SERVICE_NAME}"
+        }
+      }
+    },
+    {
+      "apiVersion": "v1",
+      "kind": "Service",
+      "metadata": {
+        "annotations": {
+        },
+        "labels": {
+          "component": "${APP_NAME}",
+          "provider": "s2i",
+          "app": "${APP_NAME}",
+          "version": "${APP_VERSION}",
+          "group": "quickstarts"
+        },
+        "name": "${SERVICE_NAME}"
+      },
+      "spec": {
+        "clusterIP": "None",
+        "deprecatedPublicIPs": [],
+        "ports": [
+          {
+            "port": 9413,
+            "protocol": "TCP",
+            "targetPort": 8080
+          }
+        ],
+        "selector": {
+          "app": "${APP_NAME}",
+          "component": "${APP_NAME}",
+          "provider": "s2i",
+          "group": "quickstarts"
+        }
+      }
+    },
     {
       "kind": "ImageStream",
       "apiVersion": "v1",


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ENTESB-16529