### PR TITLE
ENTESB-17409: Missing fuse-karaf-openshift-jdk11-rhel8 in fis-image-s…

### DIFF
--- a/fis-image-streams.json
+++ b/fis-image-streams.json
@@ -669,6 +669,39 @@
             "kind": "ImageStream",
             "apiVersion": "v1",
             "metadata": {
+                "name": "fuse7-karaf-openshift-jdk11",
+                "annotations": {
+                    "openshift.io/display-name": "Red Hat Fuse 7 Karaf Java11",
+                    "openshift.io/provider-display-name": "Red Hat, Inc."
+                }
+            },
+            "spec": {
+                "tags": [
+                    {
+                        "name": "1.10",
+                        "annotations": {
+                            "description": "Red Hat Fuse 7.0 Karaf S2I images Java11.",
+                            "openshift.io/display-name": "Red Hat Fuse 7.0 Karaf Java11",
+                            "iconClass": "icon-rh-integration",
+                            "tags": "builder,jboss-fuse,java,karaf,xpaas,hidden",
+                            "supports":"jboss-fuse:7.0.0,java:11,xpaas:1.2",
+                            "version": "1.0"
+                        },
+                        "referencePolicy": {
+                            "type": "Local"
+                        },
+                        "from": {
+                            "kind": "DockerImage",
+                            "name": "registry.redhat.io/fuse7/fuse-karaf-openshift-jdk11-rhel8:1.10"
+                        }
+                    }
+                ]
+            }
+        },
+        {
+            "kind": "ImageStream",
+            "apiVersion": "v1",
+            "metadata": {
                 "name": "fuse7-eap-openshift",
                 "annotations": {
                     "openshift.io/display-name": "Red Hat Fuse 7 EAP",


### PR DESCRIPTION
…treams.json