### PR TITLE
ENTESB-18336 Quickstarts have 1.10 version - update of 7.10

### DIFF
--- a/fis-image-streams.json
+++ b/fis-image-streams.json
@@ -419,11 +419,11 @@
                     {
                         "name": "1.11",
                         "annotations": {
-                            "description": "Red Hat Fuse 7.10 Java S2I images.",
-                            "openshift.io/display-name": "Red Hat Fuse 7.10 Java",
+                            "description": "Red Hat Fuse 7.11 Java S2I images.",
+                            "openshift.io/display-name": "Red Hat Fuse 7.11 Java",
                             "iconClass": "icon-rh-integration",
                             "tags": "builder,jboss-fuse,java,xpaas,hidden",
-                            "supports":"jboss-fuse:7.10.0,java:8,xpaas:1.2",
+                            "supports":"jboss-fuse:7.11.0,java:8,xpaas:1.2",
                             "version": "1.11"
                         },
                         "referencePolicy": {
@@ -665,11 +665,11 @@
                     {
                         "name": "1.11",
                         "annotations": {
-                            "description": "Red Hat Fuse 7.10 Karaf S2I images.",
-                            "openshift.io/display-name": "Red Hat Fuse 7.10 Karaf",
+                            "description": "Red Hat Fuse 7.11 Karaf S2I images.",
+                            "openshift.io/display-name": "Red Hat Fuse 7.11 Karaf",
                             "iconClass": "icon-rh-integration",
                             "tags": "builder,jboss-fuse,java,karaf,xpaas,hidden",
-                            "supports":"jboss-fuse:7.10.0,java:8,xpaas:1.2",
+                            "supports":"jboss-fuse:7.11.0,java:8,xpaas:1.2",
                             "version": "1.11"
                         },
                         "referencePolicy": {
@@ -684,7 +684,7 @@
                         "name": "1.11",
                         "annotations": {
                             "description": "Red Hat Fuse 7.11 Karaf S2I images.",
-                            "openshift.io/display-name": "Red Hat Fuse 7.10 Karaf",
+                            "openshift.io/display-name": "Red Hat Fuse 7.11 Karaf",
                             "iconClass": "icon-rh-integration",
                             "tags": "builder,jboss-fuse,java,karaf,xpaas,hidden",
                             "supports":"jboss-fuse:7.11.0,java:8,xpaas:1.2",
@@ -911,11 +911,11 @@
                     {
                         "name": "1.11",
                         "annotations": {
-                            "description": "Red Hat Fuse 7.10 EAP S2I images.",
-                            "openshift.io/display-name": "Red Hat Fuse 7.10 EAP",
+                            "description": "Red Hat Fuse 7.11 EAP S2I images.",
+                            "openshift.io/display-name": "Red Hat Fuse 7.11 EAP",
                             "iconClass": "icon-rh-integration",
                             "tags": "builder,jboss-fuse,java,eap,xpaas,hidden",
-                            "supports":"jboss-fuse:7.10.0,java:8,xpaas:1.2",
+                            "supports":"jboss-fuse:7.11.0,java:8,xpaas:1.2",
                             "version": "1.11"
                         },
                         "referencePolicy": {
@@ -1157,11 +1157,11 @@
                     {
                         "name": "1.11",
                         "annotations": {
-                            "description": "Red Hat Fuse 7.10 Console image.",
-                            "openshift.io/display-name": "Red Hat Fuse 7.10 Console",
+                            "description": "Red Hat Fuse 7.11 Console image.",
+                            "openshift.io/display-name": "Red Hat Fuse 7.11 Console",
                             "iconClass": "icon-rh-integration",
                             "tags": "jboss-fuse,hawtio,java,xpaas,hidden",
-                            "supports":"jboss-fuse:7.10.0,java:8,xpaas:1.2",
+                            "supports":"jboss-fuse:7.11.0,java:8,xpaas:1.2",
                             "version": "1.11"
                         },
                         "referencePolicy": {

--- a/fuse-apicurito.yml
+++ b/fuse-apicurito.yml
@@ -96,7 +96,7 @@ objects:
           component: apicurito-ui
           com.company: Red_Hat
           rht.prod_name: Red_Hat_Integration
-          rht.prod_ver: "7.10"
+          rht.prod_ver: "7.11"
           rht.comp: apicurito-ui
           rht.comp_ver: ${APP_VERSION}
       spec:
@@ -199,7 +199,7 @@ objects:
           component: fuse-apicurito-generator
           com.company: Red_Hat
           rht.prod_name: Red_Hat_Integration
-          rht.prod_ver: "7.10"
+          rht.prod_ver: "7.11"
           rht.comp: fuse-apicurito-generator
           rht.comp_ver: ${APP_VERSION}
       spec:

--- a/fuse-console-cluster-rbac.yml
+++ b/fuse-console-cluster-rbac.yml
@@ -5,7 +5,7 @@ metadata:
   labels:
     template: fuse-console
   annotations:
-    openshift.io/display-name: Red Hat Fuse 7.10 Console with RBAC (cluster)
+    openshift.io/display-name: Red Hat Fuse 7.11 Console with RBAC (cluster)
     openshift.io/provider-display-name: Red Hat, Inc.
     description: The Red Hat Fuse Console eases the discovery and management of Fuse applications deployed on OpenShift.
     tags: hawtio,java,fuse
@@ -161,7 +161,7 @@ objects:
           version: ${APP_VERSION}
           com.company: Red_Hat
           rht.prod_name: Red_Hat_Integration
-          rht.prod_ver: "7.10"
+          rht.prod_ver: "7.11"
           rht.comp: ${APP_NAME}
           rht.comp_ver: ${APP_VERSION}
       spec:


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ENTESB-18336

Addition of missing updated version (from 7.10 -> 7.11) in commit https://github.com/jboss-fuse/application-templates/commit/f65ffa099c5f3f03555a711ef6bb638f5c990d48