### PR TITLE
ENTESB-18932 - Update Fuse Console image for K8s to registry.redhat.io/fuse7/fuse-console-rhel8

### DIFF
--- a/fuse-console-cluster-k8s.yml
+++ b/fuse-console-cluster-k8s.yml
@@ -83,7 +83,7 @@ spec:
     spec:
       containers:
       - name: fuse-console
-        image: fuse7-console:1.11
+        image: registry.redhat.io/fuse7/fuse-console-rhel8:1.11
         readinessProbe:
           httpGet:
             path: /online

--- a/fuse-console-namespace-k8s.yml
+++ b/fuse-console-namespace-k8s.yml
@@ -83,7 +83,7 @@ spec:
     spec:
       containers:
       - name: fuse-console
-        image: fuse7-console:1.11
+        image: registry.redhat.io/fuse7/fuse-console-rhel8:1.11
         readinessProbe:
           httpGet:
             path: /online


### PR DESCRIPTION
Still not fully fixed yet, but this is part of the fix.
https://issues.redhat.com/browse/ENTESB-18932