### PR TITLE
Jira SO-53: Remove non-groupified API from jboss-fuse/application-templates

### DIFF
--- a/fis-console-namespace-template.json
+++ b/fis-console-namespace-template.json
@@ -1,5 +1,5 @@
 {
-  "apiVersion": "v1",
+  "apiVersion": "template.openshift.io/v1",
   "kind": "Template",
   "metadata": {
     "annotations": {

--- a/fis-console-namespace-template.json
+++ b/fis-console-namespace-template.json
@@ -83,7 +83,7 @@
     },
     {
       "kind": "Route",
-      "apiVersion": "v1",
+      "apiVersion": "route.openshift.io/v1",
       "metadata": {
         "name": "${APP_NAME}-route",
         "labels": {
@@ -154,7 +154,7 @@
     },
     {
       "kind": "DeploymentConfig",
-      "apiVersion": "v1",
+      "apiVersion": "apps.openshift.io/v1",
       "metadata": {
         "name": "${APP_NAME}",
         "creationTimestamp": null,

--- a/fis-image-streams.json
+++ b/fis-image-streams.json
@@ -1,6 +1,6 @@
 {
     "kind": "List",
-    "apiVersion": "image.openshift.io/v1",
+    "apiVersion": "v1",
     "metadata": {
         "name": "jboss-fuse-image-streams",
         "annotations": {

--- a/fis-image-streams.json
+++ b/fis-image-streams.json
@@ -10,7 +10,7 @@
     "items": [
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "fis-java-openshift",
                 "annotations": {
@@ -61,7 +61,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "jboss-fuse70-java-openshift",
                 "annotations": {
@@ -94,7 +94,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "fis-karaf-openshift",
                 "annotations": {
@@ -145,7 +145,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "jboss-fuse70-karaf-openshift",
                 "annotations": {
@@ -178,7 +178,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "jboss-fuse70-eap-openshift",
                 "annotations": {
@@ -211,7 +211,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "jboss-fuse70-console",
                 "annotations": {
@@ -244,7 +244,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "fuse7-java-openshift",
                 "annotations": {
@@ -367,7 +367,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "fuse7-karaf-openshift",
                 "annotations": {
@@ -490,7 +490,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "fuse7-eap-openshift",
                 "annotations": {
@@ -613,7 +613,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "fuse7-console",
                 "annotations": {
@@ -736,7 +736,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "apicurito-ui",
                 "annotations": {
@@ -811,7 +811,7 @@
         },
         {
             "kind": "ImageStream",
-            "apiVersion": "v1",
+            "apiVersion": "image.openshift.io/v1",
             "metadata": {
                 "name": "fuse-apicurito-generator",
                 "annotations": {

--- a/fis-image-streams.json
+++ b/fis-image-streams.json
@@ -1,6 +1,6 @@
 {
     "kind": "List",
-    "apiVersion": "v1",
+    "apiVersion": "image.openshift.io/v1",
     "metadata": {
         "name": "jboss-fuse-image-streams",
         "annotations": {

--- a/quickstarts/spring-boot-camel-rest-3scale-template.json
+++ b/quickstarts/spring-boot-camel-rest-3scale-template.json
@@ -129,7 +129,7 @@
   ],
   "objects": [
     {
-      "apiVersion": "v1",
+      "apiVersion": "route.openshift.io/v1",
       "kind": "Route",
       "metadata": {
         "labels": {
@@ -202,7 +202,7 @@
     },
     {
       "kind": "BuildConfig",
-      "apiVersion": "v1",
+      "apiVersion": "build.openshift.io/v1",
       "metadata": {
         "name": "${APP_NAME}",
         "creationTimestamp": null,
@@ -294,7 +294,7 @@
     },
     {
       "kind": "DeploymentConfig",
-      "apiVersion": "v1",
+      "apiVersion": "apps.openshift.io/v1",
       "metadata": {
         "name": "${APP_NAME}",
         "creationTimestamp": null,

--- a/quickstarts/spring-boot-camel-rest-3scale-template.json
+++ b/quickstarts/spring-boot-camel-rest-3scale-template.json
@@ -1,5 +1,5 @@
 {
-  "apiVersion": "v1",
+  "apiVersion": "template.openshift.io/v1",
   "kind": "Template",
   "metadata": {
     "annotations": {
@@ -183,7 +183,7 @@
     },
     {
       "kind": "ImageStream",
-      "apiVersion": "v1",
+      "apiVersion": "image.openshift.io/v1",
       "metadata": {
         "name": "${APP_NAME}",
         "creationTimestamp": null,

--- a/quickstarts/spring-boot-camel-template.json
+++ b/quickstarts/spring-boot-camel-template.json
@@ -143,7 +143,7 @@
     },
     {
       "kind": "BuildConfig",
-      "apiVersion": "v1",
+      "apiVersion": "build.openshift.io/v1",
       "metadata": {
         "name": "${APP_NAME}",
         "creationTimestamp": null,
@@ -235,7 +235,7 @@
     },
     {
       "kind": "DeploymentConfig",
-      "apiVersion": "v1",
+      "apiVersion": "apps.openshift.io/v1",
       "metadata": {
         "name": "${APP_NAME}",
         "creationTimestamp": null,

--- a/quickstarts/spring-boot-camel-template.json
+++ b/quickstarts/spring-boot-camel-template.json
@@ -1,5 +1,5 @@
 {
-  "apiVersion": "v1",
+  "apiVersion": "template.openshift.io/v1",
   "kind": "Template",
   "metadata": {
     "annotations": {
@@ -124,7 +124,7 @@
   "objects": [
     {
       "kind": "ImageStream",
-      "apiVersion": "v1",
+      "apiVersion": "image.openshift.io/v1",
       "metadata": {
         "name": "${APP_NAME}",
         "creationTimestamp": null,

--- a/quickstarts/spring-boot-camel-xml-template.json
+++ b/quickstarts/spring-boot-camel-xml-template.json
@@ -143,7 +143,7 @@
     },
     {
       "kind": "BuildConfig",
-      "apiVersion": "v1",
+      "apiVersion": "build.openshift.io/v1",
       "metadata": {
         "name": "${APP_NAME}",
         "creationTimestamp": null,
@@ -235,7 +235,7 @@
     },
     {
       "kind": "DeploymentConfig",
-      "apiVersion": "v1",
+      "apiVersion": "apps.openshift.io/v1",
       "metadata": {
         "name": "${APP_NAME}",
         "creationTimestamp": null,

--- a/quickstarts/spring-boot-camel-xml-template.json
+++ b/quickstarts/spring-boot-camel-xml-template.json
@@ -1,5 +1,5 @@
 {
-  "apiVersion": "v1",
+  "apiVersion": "template.openshift.io/v1",
   "kind": "Template",
   "metadata": {
     "annotations": {
@@ -124,7 +124,7 @@
   "objects": [
     {
       "kind": "ImageStream",
-      "apiVersion": "v1",
+      "apiVersion": "image.openshift.io/v1",
       "metadata": {
         "name": "${APP_NAME}",
         "creationTimestamp": null,


### PR DESCRIPTION
Non-groupified APIs were deprecated in OCP 4.7.

This PR only handles the imagestreams/Templates which are bundled in OpenShift. If any of the other imagestreams or templates are meant to still be used, they should also be similarly updated. A complete API list is available at https://docs.openshift.com/container-platform/4.10/rest_api/index.html .

Signed-off-by: Feny Mehta <fbm3307@gmail.com>