### PR TITLE
[ENTESB-19698] Quickstart S2I SpringBoot-Camel-Config: unable to get ConfigMap

### DIFF
--- a/secrets/springboot-camel-config-secret.json
+++ b/secrets/springboot-camel-config-secret.json
@@ -21,6 +21,8 @@
         "name": "qs-camel-config"
       },
       "roleRef": {
+	"apiGroup": "rbac.authorization.k8s.io",
+        "kind": "ClusterRole",
         "name": "view"
       },
       "subjects": [


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/ENTESB-19698

_apiGroup_ and _kind_ are required attributes for _roleRef_